### PR TITLE
Adc dma support

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -100,7 +100,7 @@
  *
  * :[0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
 /**
  * This setting determines the communication speed of the printer.
@@ -282,7 +282,7 @@
  *
  * :{ '0': "Not used", '1':"100k / 4.7k - EPCOS", '2':"200k / 4.7k - ATC Semitec 204GT-2", '3':"Mendel-parts / 4.7k", '4':"10k !! do not use for a hotend. Bad resolution at high temp. !!", '5':"100K / 4.7k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '6':"100k / 4.7k EPCOS - Not as accurate as Table 1", '7':"100k / 4.7k Honeywell 135-104LAG-J01", '8':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT", '9':"100k / 4.7k GE Sensing AL03006-58.2K-97-G1", '10':"100k / 4.7k RS 198-961", '11':"100k / 4.7k beta 3950 1%", '12':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT (calibrated for Makibox hot bed)", '13':"100k Hisens 3950  1% up to 300°C for hotend 'Simple ONE ' & hotend 'All In ONE'", '20':"PT100 (Ultimainboard V2.x)", '51':"100k / 1k - EPCOS", '52':"200k / 1k - ATC Semitec 204GT-2", '55':"100k / 1k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '60':"100k Maker's Tool Works Kapton Bed Thermistor beta=3950", '66':"Dyze Design 4.7M High Temperature thermistor", '70':"the 100K thermistor found in the bq Hephestos 2", '71':"100k / 4.7k Honeywell 135-104LAF-J01", '147':"Pt100 / 4.7k", '1047':"Pt1000 / 4.7k", '110':"Pt100 / 1k (non-standard)", '1010':"Pt1000 / 1k (non standard)", '-3':"Thermocouple + MAX31855 (only for sensor 0)", '-2':"Thermocouple + MAX6675 (only for sensor 0)", '-1':"Thermocouple + AD595",'998':"Dummy 1", '999':"Dummy 2" }
  */
-#define TEMP_SENSOR_0 1
+#define TEMP_SENSOR_0 11
 #define TEMP_SENSOR_1 0
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_3 0

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.cpp
@@ -182,12 +182,6 @@ void HAL_adc_init(void)
   adc.setScanMode();
   adc.setContinuous();
   adc.startConversion();
-
-  // HACK - Not needed once the pin mapping/fastio stuff is done
-  for (int i = 0; i < ADC_PIN_COUNT; i++)
-  {
-    pinMode(adc_pins[i], INPUT_ANALOG);
-  }
 }
 
 void HAL_adc_start_conversion (uint8_t adc_pin) {

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.h
@@ -56,6 +56,8 @@
 // --------------------------------------------------------------------------
 
 #if SERIAL_PORT == -1
+extern USBSerial SerialUSB;
+
 #define MYSERIAL SerialUSB
 #elif SERIAL_PORT == 0
 #define MYSERIAL Serial

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.h
@@ -175,7 +175,7 @@ void eeprom_update_block (const void *__src, void *__dst, size_t __n);
 
 #define HAL_ANALOG_SELECT(pin) pinMode(pin, INPUT_ANALOG);
 
-inline void HAL_adc_init(void) {}
+void HAL_adc_init(void);
 
 
 #define HAL_START_ADC(pin)  HAL_adc_start_conversion(pin)
@@ -204,4 +204,3 @@ void HAL_enable_AdcFreerun(void);
 // --------------------------------------------------------------------------
 
 #endif // _HAL_STM32F1_H
-

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.cpp
@@ -124,7 +124,7 @@ void HAL_timer_enable_interrupt (uint8_t timer_num) {
         StepperTimer.attachInterrupt(STEP_TIMER_CHAN, stepTC_Handler);
         break;
     case TEMP_TIMER_NUM:
-        TempTimer.attachInterrupt(STEP_TIMER_CHAN, tempTC_Handler);
+        TempTimer.attachInterrupt(TEMP_TIMER_CHAN, tempTC_Handler);
         break;
     default:
         break;
@@ -137,7 +137,7 @@ void HAL_timer_disable_interrupt (uint8_t timer_num) {
         StepperTimer.detachInterrupt(STEP_TIMER_CHAN);
         break;
     case TEMP_TIMER_NUM:
-        TempTimer.detachInterrupt(STEP_TIMER_CHAN);
+        TempTimer.detachInterrupt(TEMP_TIMER_CHAN);
         break;
     default:
         break;

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -48,7 +48,7 @@
 #define HAL_TIMER_TYPE uint16_t
 #define HAL_TIMER_TYPE_MAX 0xFFFF
 
-#define STEP_TIMER_NUM 5  // index of timer to use for stepper
+#define STEP_TIMER_NUM 4  // index of timer to use for stepper
 #define STEP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts
 #define TEMP_TIMER_NUM 2  // index of timer to use for temperature
 #define TEMP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -48,11 +48,12 @@
 #define HAL_TIMER_TYPE uint16_t
 #define HAL_TIMER_TYPE_MAX 0xFFFF
 
-#define STEP_TIMER_NUM 4  // index of timer to use for stepper
+// index of timer to use for stepper
+#define STEP_TIMER_NUM 4
+
 #define STEP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts
 #define TEMP_TIMER_NUM 2  // index of timer to use for temperature
 #define TEMP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts
-
 
 #define HAL_TIMER_RATE         (F_CPU)  // frequency of timers peripherals
 #define STEPPER_TIMER_PRESCALE 36             // prescaler for setting stepper timer, 2Mhz

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
@@ -1,0 +1,131 @@
+/**
+ * Marlin 3D Printer Firmware
+ *
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
+ * Copyright (c) 2015-2016 Nico Tonnhofer wurstnase.reprap@gmail.com
+ * Copyright (c) 2016 Victor Perez victor_pv@hotmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Description: HAL for stm32duino and compatible (STM32F1)
+ * Implementation of EEPROM settings in SDCard
+ *
+ * For __STM32F1__
+ */
+
+#ifdef __STM32F1__
+
+#include "../../inc/MarlinConfig.h"
+
+// This is for EEPROM emulation in flash
+#if ENABLED(EEPROM_SETTINGS) && ENABLED(FLASH_EEPROM_EMULATION)
+
+#include "../persistent_store_api.h"
+
+#include <flash_stm32.h>
+#include <EEPROM.h>
+
+namespace HAL {
+namespace PersistentStore {
+
+// Store settings in the last two pages
+// Flash pages must be erased before writing, so keep track.
+bool firstWrite = false;
+uint32_t pageBase = EEPROM_START_ADDRESS;
+
+bool access_start() {
+	firstWrite = true;
+	return true;
+}
+
+
+bool access_finish(){
+	FLASH_Lock();
+	firstWrite = false;
+	return true;
+}
+
+bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+	FLASH_Status status;
+
+	if (firstWrite)
+	{
+		FLASH_Unlock();
+
+		status = FLASH_ErasePage(EEPROM_PAGE0_BASE);
+		if (status != FLASH_COMPLETE)
+		{
+			return false;
+		}
+
+		status = FLASH_ErasePage(EEPROM_PAGE1_BASE);
+		if (status != FLASH_COMPLETE)
+		{
+			return false;
+		}
+
+		firstWrite = false;
+	}
+
+  // First write full words
+	int i = 0;
+	int wordsToWrite = size/sizeof(uint16_t);
+	uint16_t* wordBuffer = (uint16_t *)value;
+  while (wordsToWrite)
+	{
+		status = FLASH_ProgramHalfWord(pageBase + pos + (i * 2), wordBuffer[i]);
+		if (status != FLASH_COMPLETE)
+		{
+			return false;
+		}
+    wordsToWrite--;
+    i++;
+	}
+
+  // Now, write any remaining single byte
+  if (size & 1)
+	{
+		uint16_t temp = value[size-1];
+
+		status = FLASH_ProgramHalfWord(pageBase+pos+i, temp);
+		if (status != FLASH_COMPLETE)
+		{
+			return false;
+		}
+	}
+
+	crc16(crc, value, size);
+  pos += ((size + 1) & ~1);
+	return true;
+}
+
+void read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc) {
+	for (int i = 0; i < size; i++) {
+    byte* accessPoint = (byte*)(pageBase + pos + i);
+		value[i] = *accessPoint;
+	}
+
+	crc16(crc, value, size);
+	pos += ((size + 1) & ~1);
+}
+
+}
+}
+
+#endif // EEPROM_SETTINGS && EEPROM FLASH
+#endif // __STM32F1__

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -665,6 +665,13 @@ void setup() {
     Max7219_init();
   #endif
 
+  // DO NOT COMMIT!
+  // Set up for Re-init USB
+  pinMode(BOARD_USB_DISC_BIT, OUTPUT);
+  digitalWrite(BOARD_USB_DISC_BIT, LOW);
+  SerialUSB.end();
+  SerialUSB.begin();
+
   #ifdef DISABLE_JTAG
     // Disable JTAG on AT90USB chips to free up pins for IO
     MCUCR = 0x80;

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -129,6 +129,7 @@
 #define BOARD_RAMPS_14_RE_ARM_EEF      1746   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
 #define BOARD_RAMPS_14_RE_ARM_SF       1748   // Re-ARM with RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
 #define BOARD_STM32F1R         1800  // STM3R Libmaple based stm32f1 controller
+#define BOARD_MALYAN_M200         1801  // STM32C8T6 Libmaple based stm32f1 controller
 
 #define MB(board) (MOTHERBOARD==BOARD_##board)
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -280,8 +280,11 @@ void MarlinSettings::postprocess() {
     EEPROM_START();
 
     eeprom_error = false;
-
+ #if ENABLED(FLASH_EEPROM_EMULATION)
+    EEPROM_SKIP(ver); // Flash doesn't allow rewriting without erase
+#else
     EEPROM_WRITE(ver);     // invalidate data first
+#endif
     EEPROM_SKIP(working_crc); // Skip the checksum slot
 
     working_crc = 0; // clear before first "real data"

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -45,7 +45,7 @@
   #define IS_RAMPS_EFF
 #elif MB(RAMPS_13_EEF) || MB(RAMPS_14_EEF) || MB(RAMPS_14_RE_ARM_EEF) || MB(RAMPS_SMART_EEF) || MB(RAMPS_DUO_EEF) || MB(RAMPS4DUE_EEF)
   #define IS_RAMPS_EEF
-#elif MB(RAMPS_13_SF)  || MB(RAMPS_14_SF)  || MB(RAMPS_14_RE_ARM_SF)  || MB(RAMPS_SMART_SF)  || MB(RAMPS_DUO_SF)  || MB(RAMPS4DUE_SF) 
+#elif MB(RAMPS_13_SF)  || MB(RAMPS_14_SF)  || MB(RAMPS_14_RE_ARM_SF)  || MB(RAMPS_SMART_SF)  || MB(RAMPS_DUO_SF)  || MB(RAMPS4DUE_SF)
   #define IS_RAMPS_SF
 #endif
 
@@ -300,6 +300,8 @@
   #include "pins_ALLIGATOR_R2.h"
 #elif MB(STM32F1R)
   #include "pins_STM32F1R.h"
+#elif MB(MALYAN_M200)
+  #include "pins_MALYAN_M200.h"
 #else
   #error "Unknown MOTHERBOARD value set in Configuration.h"
 #endif

--- a/Marlin/src/pins/pins_Malyan_M200.h
+++ b/Marlin/src/pins/pins_Malyan_M200.h
@@ -1,0 +1,80 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * MALYAN M200 pin assignments
+ */
+
+#ifndef __STM32F1__
+  #error "Oops! You must be compiling for STM32."
+#endif
+
+#define BOARD_NAME "MALYANM200"
+
+// Enable EEPROM Emulation for this board
+#define FLASH_EEPROM_EMULATION
+
+// PINCHECK - Looking at traces, 38 and 35 are to some endstop. Y is uncertain
+//
+// Limit Switches
+//
+#define X_MIN_PIN          14 //37
+#define Y_MIN_PIN          15   // 41
+#define Z_MIN_PIN          16  //38
+
+//
+// Steppers
+//
+#define X_STEP_PIN          29
+#define X_DIR_PIN           28
+#define X_ENABLE_PIN       27
+
+#define Y_STEP_PIN         29 //40
+#define Y_DIR_PIN          28 //26
+#define Y_ENABLE_PIN       27 //25
+
+#define Z_STEP_PIN         29 //22 // Z1 STP
+#define Z_DIR_PIN          28 //20 // Z1 DIR
+#define Z_ENABLE_PIN       27 //21 // Z1 ENA
+
+// PINCHECK - E0 DIIR is unknown
+#define E0_STEP_PIN        29 //21 // Z2 STP
+#define E0_DIR_PIN         28 //30 // Z2 DIR
+#define E0_ENABLE_PIN      27 //18 // Z2 ENA
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         11   // Analog Input (HOTEND0 thermistor)
+#define TEMP_BED_PIN        10   // Analog Input (BED thermistor)
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN       13   //43 // HOTEND0 MOSFET
+#define HEATER_BED_PIN     13 // 42 // BED MOSFET
+
+// PINCHECK - Need to find pin assignment for these.
+// This board has only the controller fan and the extruder fan
+//#define FAN_PIN            -1 // FAN1 header on board - PRINT FAN
+#define FAN1_PIN            -1 // FAN2 header on board - CONTROLLER FAN
+#define FAN2_PIN           -1 // FAN3 header on board - EXTRUDER0 FAN

--- a/Marlin/src/pins/pins_Malyan_M200.h
+++ b/Marlin/src/pins/pins_Malyan_M200.h
@@ -67,7 +67,7 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN         11   // Analog Input (HOTEND0 thermistor)
+#define TEMP_0_PIN         PA1   // Analog Input (HOTEND0 thermistor)
 #define TEMP_BED_PIN        0   // Analog Input (BED thermistor)
 
 //

--- a/Marlin/src/pins/pins_Malyan_M200.h
+++ b/Marlin/src/pins/pins_Malyan_M200.h
@@ -30,6 +30,9 @@
 
 #define BOARD_NAME "MALYANM200"
 
+// ignore temp readings during develpment.
+#define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
+
 // Enable EEPROM Emulation for this board
 #define FLASH_EEPROM_EMULATION
 
@@ -65,13 +68,13 @@
 // Temperature Sensors
 //
 #define TEMP_0_PIN         11   // Analog Input (HOTEND0 thermistor)
-#define TEMP_BED_PIN        10   // Analog Input (BED thermistor)
+#define TEMP_BED_PIN        0   // Analog Input (BED thermistor)
 
 //
 // Heaters / Fans
 //
 #define HEATER_0_PIN       13   //43 // HOTEND0 MOSFET
-#define HEATER_BED_PIN     13 // 42 // BED MOSFET
+#define HEATER_BED_PIN     0 // 42 // BED MOSFET
 
 // PINCHECK - Need to find pin assignment for these.
 // This board has only the controller fan and the extruder fan

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ src_dir = Marlin
 envs_dir = .pioenvs
 lib_dir = .piolib
 libdeps_dir = .piolibdeps
-env_default = megaatmega2560
+env_default = STM32
 
 [common]
 lib_deps =
@@ -121,3 +121,21 @@ lib_ldf_mode = off
 lib_extra_dirs = frameworks
 lib_deps = U8glib-ARM, CMSIS-LPC1768
 extra_scripts = Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+
+[env:STM32]
+platform = ststm32
+board = genericSTM32F103CB
+framework = arduino
+#if running on a bluepill, add -DSERIAL_USB -D BOARD_USB_DISC_DEV=GPIOA -D BOARD_USB_DISC_BIT=12
+build_flags = -D __STM32F1__=1 -std=c++1y -D MOTHERBOARD="BOARD_MALYAN_M200" -D SERIAL_USB=1 -D BOARD_USB_DISC_DEV=GPIOA -D BOARD_USB_DISC_BIT=12
+src_filter = ${common.default_src_filter} -<frameworks>
+lib_ignore =
+  U8glib
+  LiquidCrystal_I2C
+  LiquidCrystal
+  NewliquidCrystal
+  LiquidTWI2
+  Adafruit NeoPixel
+  TMC2130Stepper
+  Servo(STM32F1)
+  TMC26XStepper


### PR DESCRIPTION
This adds support for the ADC in DMA mode (I tested by soldering & connecting thermisters/pull up resistors). Longer term, it would make sense for the ADC read functions to be macros that pull the data from the right index in the DMA buffer since the ADC runs in continuous mode and the buffer is always up to date, but this works perfectly well for now. 