### PR TITLE
Switch all enums to be within #defines

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.cpp
@@ -51,6 +51,7 @@
 // --------------------------------------------------------------------------
 // Variables
 // --------------------------------------------------------------------------
+STM32ADC adc(ADC1);
 
 // --------------------------------------------------------------------------
 // Public Variables
@@ -88,16 +89,30 @@ uint8 adc_pins[] = {
 
 enum TEMP_PINS
 {
+  #if HAS_TEMP_0
     TEMP_0,
+  #endif
+  #if HAS_TEMP_1
     TEMP_1,
+  #endif
+  #if HAS_TEMP_2
     TEMP_2,
+  #endif
+  #if HAS_TEMP_3
     TEMP_3,
+  #endif
+  #if HAS_TEMP_4
     TEMP_4,
+  #endif
+  #if HAS_TEMP_BED
     TEMP_BED,
-    FILWIDTH
+  #endif
+  #if ENABLED(FILAMENT_WIDTH_SENSOR)
+    FILWIDTH,
+  #endif
+    ADC_PIN_COUNT
 };
 
-#define ADC_PIN_COUNT (sizeof(adc_pins)/sizeof(adc_pins[0]))
 uint16_t HAL_adc_results[ADC_PIN_COUNT];
 
 
@@ -180,30 +195,44 @@ void HAL_adc_init(void)
 
 void HAL_adc_start_conversion (uint8_t adc_pin) {
   TEMP_PINS pin_index = TEMP_0;
-  if (adc_pin == TEMP_0_PIN){
-      pin_index = TEMP_0;
-  }
 
-  else if (adc_pin == TEMP_1_PIN) {
+  switch (adc_pin) {
+  #if HAS_TEMP_0
+    case TEMP_0_PIN:
+        pin_index = TEMP_0;
+        break;
+  #endif
+  #if HAS_TEMP_1
+    case TEMP_1_PIN:
     pin_index = TEMP_1;
-  }
-  else if (adc_pin == TEMP_2_PIN) {
+    break;
+  #endif
+  #if HAS_TEMP_2
+    case TEMP_2_PIN:
     pin_index = TEMP_2;
-  }
-  else if (adc_pin == TEMP_3_PIN) {
+    break;
+  #endif
+  #if HAS_TEMP_3
+    case TEMP_3_PIN:
     pin_index = TEMP_3;
-  }
-  else if (adc_pin == TEMP_4_PIN) {
+    break;
+  #endif
+  #if HAS_TEMP_4
+    case TEMP_4_PIN:
     pin_index = TEMP_4;
-  }
-  else if (adc_pin == TEMP_BED_PIN) {
+    break;
+  #endif
+  #if HAS_TEMP_BED
+    case TEMP_BED_PIN:
     pin_index = TEMP_BED;
-  }
-#if ENABLED(FILAMENT_WIDTH_SENSOR)
-  else if (adc_pin == FILWIDTH_PIN) {
+    break;
+  #endif
+  #if ENABLED(FILAMENT_WIDTH_SENSOR)
+    case FILWIDTH_PIN:
     pin_index = FILWIDTH;
+    break;
+  #endif
   }
-#endif
 
   HAL_adc_result = (HAL_adc_results[(int)pin_index] >> 2)& 0x3ff; // shift to get 10 bits only.
 }


### PR DESCRIPTION
This change allows a user to have, for instance, TEMP_4 and TEMP_BED definied but nothing else. The enums which are not defined move "out", allowing the first ones to take the slots in the enum, and since the array is sized on ADC_PIN_COUNT, we always have the right size data and in order.