### PR TITLE
Don't wait forever for a serial connection at startup

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -681,7 +681,11 @@ void setup() {
   #endif
 
   MYSERIAL.begin(BAUDRATE);
-  while(!MYSERIAL);
+
+  #if ENABLED(WAIT_FOR_SERIAL_STARTUP)
+    SERIAL_START;
+  #endif
+
   SERIAL_PROTOCOLLNPGM("start");
   SERIAL_ECHO_START();
 

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -64,6 +64,8 @@ extern uint8_t marlin_debug_flags;
 extern const char echomagic[] PROGMEM;
 extern const char errormagic[] PROGMEM;
 
+#define SERIAL_START do { for (int i = 0; i < WAIT_FOR_SERIAL_STARTUP; i++) { if(!MYSERIAL) { watchdog_reset(); delay(1000);} } } while (0)
+
 #define SERIAL_CHAR(x) ((void)MYSERIAL.write(x))
 #define SERIAL_EOL() SERIAL_CHAR('\n')
 


### PR DESCRIPTION
Developers can define WAIT_FOR_SERIAL_STARTUP as the number of seconds to wait. This fix feeds the watchdog so that on systems where hardware option bytes start it running at reset, the printer doesn't restart while waiting for a connection.