### PR TITLE
Choose the timer based on MCU defintion. Timer5 is not valid on C8/CB…

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -46,7 +46,12 @@
 #define HAL_TIMER_TYPE uint16_t
 #define HAL_TIMER_TYPE_MAX 0xFFFF
 
-#define STEP_TIMER_NUM 5  // index of timer to use for stepper
+#ifdef MCU_STM32F103CB  || defined(MCU_STM32F103C8)
+  #define STEP_TIMER_NUM 4 // For C8/CB boards, use timer 4
+#else
+  #define STEP_TIMER_NUM 5 // for other boards, five is fine.
+#endif
+
 #define STEP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts
 #define TEMP_TIMER_NUM 2  // index of timer to use for temperature
 #define TEMP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts


### PR DESCRIPTION
… class boards, so use Timer4 for the step timer. This should work on both advanced boards like the F104 boards and basic hardware like the F103 boards.